### PR TITLE
Add a helper to force a connection to secondbase

### DIFF
--- a/lib/secondbase.rb
+++ b/lib/secondbase.rb
@@ -1,5 +1,6 @@
 require 'active_record'
 require 'secondbase/active_record/patches'
+require 'secondbase/force_secondbase'
 
 module SecondBase
   CONNECTION_PREFIX = 'secondbase'

--- a/lib/secondbase/force_secondbase.rb
+++ b/lib/secondbase/force_secondbase.rb
@@ -1,0 +1,19 @@
+module Secondbase
+  module ForceSecondbase
+    def connection_pool
+      SecondBase::Base.connection_pool
+    end
+  
+    def retrieve_connection
+      SecondBase::Base.retrieve_connection
+    end
+  
+    def connected?
+      SecondBase::Base.connected?
+    end
+  
+    def remove_connection(klass = self)
+      SecondBase::Base.remove_connection
+    end
+  end
+end


### PR DESCRIPTION
Lets you get around situations where you can't change the class inheritance but need to force the model to use secondbase. 

cc @nhessler @ashirazi @AEgan @astupka 