### PR TITLE
Test Forced Connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ class User < ActiveRecord::Base
 end
 ```
 
+#### Forced Connections
+
+Sometimes you want to force a model that inherits from `ActiveRecord::Base` to use the `SecondBase::Base` connection. Using the `SecondBase::Forced` module is a great way to accomplish this. By using this module, we do all the work to ensure the connection, management, and pool are properly freedom patched.
+
+We recomend forcing modules using a Rails initializer. Here is an example that forces the [DelayedJob ActiveRecord Backend](https://github.com/collectiveidea/delayed_job_active_record) to use your second DB connection.
+
+```ruby
+# In config/initializers/delayed_job.rb
+Delayed::Backend::ActiveRecord::Job.extend SecondBase::Forced
+```
+
+
 ## Versions
 
 The current master branch is for Rails v4.0.0 and up and. We have older work in previous v1.0 releases which partial work for Rails 3.2 or lower. These old versions are feature incomplete and are not supported.

--- a/test/cases/forced_test.rb
+++ b/test/cases/forced_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+class ForcedTest < SecondBase::TestCase
+
+  setup do
+    run_db_create
+    run_db_migrate
+    establish_connection
+  end
+
+  def test_shared_pool
+    assert_equal SecondBase::Base.connection_pool.object_id,
+                 CommentForced.connection_pool.object_id
+  end
+
+  def test_shared_connection
+    assert_equal SecondBase::Base.connection.raw_connection.object_id,
+                 CommentForced.connection.raw_connection.object_id
+  end
+
+  def test_shared_new_connection_in_a_different_thread
+    current_base_connection_id = SecondBase::Base.connection.raw_connection.object_id
+    new_base_connection_id, new_forced_connection_id = Thread.new {
+      [ SecondBase::Base.connection.raw_connection.object_id,
+        CommentForced.connection.raw_connection.object_id ]
+    }.value
+    refute_equal new_base_connection_id, current_base_connection_id
+    assert_equal new_base_connection_id, new_forced_connection_id
+  end
+
+  def test_shared_connected_query
+    assert SecondBase::Base.connected?
+    assert CommentForced.connected?
+    CommentForced.clear_all_connections!
+    refute SecondBase::Base.connected?
+    refute CommentForced.connected?
+  end
+
+  def test_can_remove_connection_properly
+    base_connection = SecondBase::Base.connection
+    forced_connection = CommentForced.connection
+    assert base_connection.active?
+    assert forced_connection.active?
+    CommentForced.remove_connection
+    refute base_connection.active?
+    refute forced_connection.active?
+  end
+
+end

--- a/test/cases/rake_test.rb
+++ b/test/cases/rake_test.rb
@@ -3,8 +3,8 @@ require 'test_helper'
 class RakeTest < SecondBase::TestCase
 
   def test_db_migrate
-    rake_db_create
-    Dir.chdir(dummy_root) { `rake db:migrate` }
+    run_db_create
+    run_db_migrate
     # First database and schema.
     schema = File.read(dummy_schema)
     assert_match %r{version: 20141214142700}, schema
@@ -23,30 +23,30 @@ class RakeTest < SecondBase::TestCase
 
   def test_db_create
     refute_dummy_databases
-    rake_db_create
+    run_db_create
     assert_dummy_databases
   end
 
   def test_db_drop
-    rake_db_create
-    Dir.chdir(dummy_root) { `rake db:drop` }
+    run_db_create
+    run_db_drop
     refute_dummy_databases
   end
 
   def test_db_test_purge
-    rake_db_create
+    run_db_create
     assert_dummy_databases
-    rake_db_purge
+    run_db_purge
     reestablish_connection
     assert_equal [], ActiveRecord::Base.connection.tables
     assert_equal [], SecondBase::Base.connection.tables
   end
 
   def test_db_test_load_schema
-    rake_db_create
+    run_db_create
     assert_dummy_databases
-    rake_db_purge
-    Dir.chdir(dummy_root) { `rake db:migrate` }
+    run_db_purge
+    run_db_migrate
     Dir.chdir(dummy_root) { `rake db:test:load_schema` }
     reestablish_connection
     assert_connection_tables ActiveRecord::Base, ['users', 'posts']
@@ -54,19 +54,17 @@ class RakeTest < SecondBase::TestCase
   end
 
   def test_abort_if_pending
-    rake_db_create
-    Dir.chdir(dummy_root) { `rake db:migrate` }
-    Dir.chdir(dummy_root) { `rake db:abort_if_pending_migrations` }
-    assert_equal 0, $?.exitstatus
+    run_db_create
+    run_db_migrate
+    assert_equal "", run_db_pending_migrations
     FileUtils.touch(dummy_migration)
-    Dir.chdir(dummy_root) { `rake db:abort_if_pending_migrations` }
-    assert_equal 1, $?.exitstatus
+    assert_match /run.*db:migrate.*try again/i, run_db_pending_migrations
   end
 
   def test_db_test_load_structure
-    rake_db_create
+    run_db_create
     assert_dummy_databases
-    rake_db_purge
+    run_db_purge
     Dir.chdir(dummy_root) { `env SCHEMA_FORMAT=sql rake db:migrate` }
     Dir.chdir(dummy_root) { `rake db:test:load_structure` }
     reestablish_connection
@@ -91,12 +89,24 @@ class RakeTest < SecondBase::TestCase
     end
   end
 
-  def rake_db_create
+  def run_db_create
     Dir.chdir(dummy_root) { `rake db:create` }
   end
 
-  def rake_db_purge
+  def run_db_purge
     Dir.chdir(dummy_root) { `rake db:test:purge` }
+  end
+
+  def run_db_migrate
+    Dir.chdir(dummy_root) { `rake db:migrate` }
+  end
+
+  def run_db_pending_migrations
+    capture(:stderr) { Dir.chdir(dummy_root) { `rake db:abort_if_pending_migrations` } }
+  end
+
+  def run_db_drop
+    Dir.chdir(dummy_root) { `rake db:drop` }
   end
 
 end

--- a/test/cases/rake_test.rb
+++ b/test/cases/rake_test.rb
@@ -37,7 +37,7 @@ class RakeTest < SecondBase::TestCase
     run_db_create
     assert_dummy_databases
     run_db_purge
-    reestablish_connection
+    establish_connection
     assert_equal [], ActiveRecord::Base.connection.tables
     assert_equal [], SecondBase::Base.connection.tables
   end
@@ -48,7 +48,7 @@ class RakeTest < SecondBase::TestCase
     run_db_purge
     run_db_migrate
     Dir.chdir(dummy_root) { `rake db:test:load_schema` }
-    reestablish_connection
+    establish_connection
     assert_connection_tables ActiveRecord::Base, ['users', 'posts']
     assert_connection_tables SecondBase::Base, ['comments']
   end
@@ -67,7 +67,7 @@ class RakeTest < SecondBase::TestCase
     run_db_purge
     Dir.chdir(dummy_root) { `env SCHEMA_FORMAT=sql rake db:migrate` }
     Dir.chdir(dummy_root) { `rake db:test:load_structure` }
-    reestablish_connection
+    establish_connection
     assert_connection_tables ActiveRecord::Base, ['users', 'posts']
     assert_connection_tables SecondBase::Base, ['comments']
   end
@@ -75,38 +75,13 @@ class RakeTest < SecondBase::TestCase
 
   private
 
-  def reestablish_connection
-    ActiveRecord::Base.establish_connection
-    SecondBase::Base.establish_connection(SecondBase.config)
-  end
-
   def assert_connection_tables(model, expected_tables)
-    reestablish_connection
+    establish_connection
     tables = model.connection.tables
     expected_tables.each do |table|
       message = "Expected #{model.name} tables #{tables.inspect} to include #{table.inspect}"
       assert tables.include?(table), message
     end
-  end
-
-  def run_db_create
-    Dir.chdir(dummy_root) { `rake db:create` }
-  end
-
-  def run_db_purge
-    Dir.chdir(dummy_root) { `rake db:test:purge` }
-  end
-
-  def run_db_migrate
-    Dir.chdir(dummy_root) { `rake db:migrate` }
-  end
-
-  def run_db_pending_migrations
-    capture(:stderr) { Dir.chdir(dummy_root) { `rake db:abort_if_pending_migrations` } }
-  end
-
-  def run_db_drop
-    Dir.chdir(dummy_root) { `rake db:drop` }
   end
 
 end

--- a/test/dummy_app/app/models/comment_forced.rb
+++ b/test/dummy_app/app/models/comment_forced.rb
@@ -1,0 +1,6 @@
+class CommentForced < ActiveRecord::Base
+  self.table_name = 'comments'
+  belongs_to :user
+end
+
+CommentForced.extend SecondBase::Forced

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,7 @@
-require 'bundler'
-Bundler.require :development, :test
+ENV['RAILS_ENV'] ||= 'test'
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
+require 'bundler/setup'
+Bundler.require :default, :test
 require 'second_base'
 require 'active_support/test_case'
 require 'active_support/testing/autorun'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,14 @@ module SecondBase
     setup    :delete_dummy_files
     teardown :delete_dummy_files
 
+    private
+
+    def establish_connection
+      ActiveRecord::Base.establish_connection
+      ActiveRecord::Base.connection
+      SecondBase::Base.establish_connection(SecondBase.config)
+      SecondBase::Base.connection
+    end
 
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,8 +7,7 @@ require 'active_support/test_case'
 require 'active_support/testing/autorun'
 require 'dummy_app/init'
 require 'rails/test_help'
-require 'test_helpers/rails_version_helpers'
-require 'test_helpers/dummy_app_helpers'
+Dir['test/test_helpers/*.{rb}'].each { |f| require_relative "../#{f}" }
 
 ActiveSupport.test_order = :random if ActiveSupport.respond_to?(:test_order)
 
@@ -18,7 +17,8 @@ module SecondBase
     self.use_transactional_fixtures = false
 
     include RailsVersionHelpers,
-            DummyAppHelpers
+            DummyAppHelpers,
+            StreamHelpers
 
     setup    :delete_dummy_files
     teardown :delete_dummy_files

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 require 'bundler/setup'
-Bundler.require :default, :test
+Bundler.require :default, :development
 require 'second_base'
 require 'active_support/test_case'
 require 'active_support/testing/autorun'

--- a/test/test_helpers/stream_helpers.rb
+++ b/test/test_helpers/stream_helpers.rb
@@ -1,0 +1,40 @@
+module SecondBase
+  module StreamHelpers
+
+    private
+
+    def silence_stream(stream)
+      old_stream = stream.dup
+      stream.reopen(IO::NULL)
+      stream.sync = true
+      yield
+    ensure
+      stream.reopen(old_stream)
+      old_stream.close
+    end
+
+    def quietly
+      silence_stream(STDOUT) do
+        silence_stream(STDERR) do
+          yield
+        end
+      end
+    end
+
+    def capture(stream)
+      stream = stream.to_s
+      captured_stream = Tempfile.new(stream)
+      stream_io = eval("$#{stream}")
+      origin_stream = stream_io.dup
+      stream_io.reopen(captured_stream)
+      yield
+      stream_io.rewind
+      return captured_stream.read
+    ensure
+      captured_stream.close
+      captured_stream.unlink
+      stream_io.reopen(origin_stream)
+    end
+
+  end
+end


### PR DESCRIPTION
Changes also include:

* Allow `$ ruby -I"lib:test" ...` runner by loading Bundler as needed.
* New `StreamHelpers` to use `capture` for db migrate pending. Keeps test output clean and puts assertions on the `$stderr` message vs the return code.
* Change `rake_` test helpers to `run_` since Rails 5 does not use rake. Will keep names forward consistent. Also moved these helpers to the `DummyAppHelpers` module so other tests can share them.
* Move `establish_connection` helper to base test case in helper. Call `connection` for each model to ensure it actually re-connects after establishing the connection.