### PR TITLE
Support Rails 4.2 Test DB Sync Strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ This will not only create your base development database, but it will also creat
 * db:purge:all
 * db:migrate
 * db:test:purge
+* db:test:prepare
 
 Not all base database tasks make sense to run a mirrored SecondBase task. These include tasks that move a single migration up/down, reporting on your database's current status/version, and others. These tasks have to be run explicitly and only operate on your SecondBase database. Each support any feature that their matching `:db` task has. For example, using `VERSION=123` to target a specific migration.
 
@@ -94,6 +95,17 @@ We recomend forcing modules using a Rails initializer. This example below forces
 # In config/initializers/second_base.rb
 Delayed::Backend::ActiveRecord::Job.extend SecondBase::Forced
 ActiveRecord::SessionStore::Session.extend SecondBase::Forced
+```
+
+#### Testing & DB Synchronization
+
+Rails 4.2 brought about a new way to keep your test database in sync by checking schema migrations. Where previously forcing a full test database schema load, Rails 4.2 and up is able to run your tests much faster. In order for SecondBase to take advantage of this, you will need to include our test help file directly following the Rails one. Open your `test_helper.rb` and add our `second_base/test_help` after `rails/test_help`.
+
+```ruby
+ENV["RAILS_ENV"] = "test"
+require File.expand_path('../../config/environment', __FILE__)
+require 'rails/test_help'
+require 'second_base/test_help'
 ```
 
 #### Configurations

--- a/lib/second_base/databases.rake
+++ b/lib/second_base/databases.rake
@@ -103,6 +103,10 @@ namespace :db do
         SecondBase.on_base { Rake::Task['db:test:load_structure'].execute }
       end
 
+      task :prepare do
+        SecondBase.on_base { Rake::Task['db:test:prepare'].execute }
+      end
+
     end
 
   end
@@ -112,7 +116,7 @@ end
   create:all create drop drop:all purge:all purge
   migrate abort_if_pending_migrations
   schema:load structure:load
-  test:purge test:load_schema test:load_structure
+  test:purge test:load_schema test:load_structure test:prepare
 }.each do |name|
   task = Rake::Task["db:#{name}"] rescue nil
   next unless task

--- a/lib/second_base/test_help.rb
+++ b/lib/second_base/test_help.rb
@@ -1,0 +1,11 @@
+if defined?(ActiveRecord::Base)
+
+  # Support test schema sync for Rails 4.2.x and up.
+  if ActiveRecord::Migration.respond_to? :maintain_test_schema!
+    SecondBase.on_base do
+      ActiveRecord::Migration.maintain_test_schema!
+    end
+  end
+
+
+end


### PR DESCRIPTION
Confirmed with this commit in the ENCOM test application. https://github.com/customink/encom_dbs/commit/6c46cf1155f1316e8c77ef14d2614f57b590ec44 After including `second_base/test_help`:

```
$ rails generate second_base:migration CreateUsers email:string timestamps
$ rake db:migrate
$ rake test
```

And migrations are automatically detected, db:test:prepare ran, and connections cleared and re-established. Epic success!