### PR TITLE
Allow ENV setting for SecondBase connection

### DIFF
--- a/lib/second_base.rb
+++ b/lib/second_base.rb
@@ -13,8 +13,12 @@ module SecondBase
   autoload :Base
 
   def self.config(env = nil)
-    config = ActiveRecord::Base.configurations[Railtie.config_key]
-    config ? config[env || Rails.env] : nil
+    if ENV['SECONDBASE_DATABASE_URL'].present?
+      ENV['SECONDBASE_DATABASE_URL']
+    else
+      config = ActiveRecord::Base.configurations[Railtie.config_key]
+      config ? config[env || Rails.env] : nil
+    end
   end
 
 end


### PR DESCRIPTION
This is modeled after how ActiveRecord gives priority to a `ENV['DATABASE_URL]` connection. It allows the same flexibility of not having your production credentials in your `database.yml` file.