### PR TITLE
Schema Cache Support

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -14,6 +14,6 @@ appraise 'rails42' do
 end
 
 appraise 'rails50' do
-  gem 'rails', '~> 5.0.0.rc2'
+  gem 'rails', '~> 5.0.0'
   gem 'mysql2'
 end

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ end
 
 #### The Schema Cache
 
-The ActiveRecord schema cache can serialize your database's structure to avoid complex reflection SQL. Read more in about it in the [Rails feature that you've never heard about: schema cache](http://blog.iempire.ru/2016/12/13/schema-cache/) article. Second base supports this by automatically dumping the SecondBase cache into the `db/secondbase` directory. However, in order to load this file if present, you will need to create a Rails initializer that loads this file. For example:
+The ActiveRecord schema cache can serialize your database's structure to avoid complex reflection SQL. Read more about it in this *[Rails feature that you've never heard about: schema cache](http://blog.iempire.ru/2016/12/13/schema-cache/)* article. SecondBase supports this by automatically dumping the SecondBase cache into the `db/secondbase` directory. However, in order to load this file if present, you will need to create a Rails initializer that loads this file. For example:
 
 ```ruby
 # In config/initializers/second_base.rb

--- a/README.md
+++ b/README.md
@@ -168,23 +168,6 @@ class ApplicationController < ActionController::Base
 end
 ```
 
-#### The Schema Cache
-
-The ActiveRecord schema cache can serialize your database's structure to avoid complex reflection SQL. Read more about it in this *[Rails feature that you've never heard about: schema cache](http://blog.iempire.ru/2016/12/13/schema-cache/)* article. SecondBase supports this by automatically dumping the SecondBase cache into the `db/secondbase` directory. However, in order to load this file if present, you will need to create a Rails initializer that loads this file. For example:
-
-```ruby
-# In config/initializers/second_base.rb
-Rails.application.configure do
-  use_cache  = config.active_record.use_schema_cache_dump
-  cache_file = Rails.root.join(config.second_base.path, 'schema_cache.dump')
-  if use_cache && File.file?(cache_file)
-    cache = Marshal.load File.binread(cache_file)
-    SecondBase::Base.connection.schema_cache = cache
-  end
-end
-```
-
-
 ## Versions
 
 The current master branch is for Rails v4.0.0 and up and. We have older work in previous v1.0 releases which partial work for Rails 3.2 or lower. These old versions are feature incomplete and are not supported.

--- a/gemfiles/rails50.gemfile
+++ b/gemfiles/rails50.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 5.0.0.rc2"
+gem "rails", "~> 5.0.0"
 gem "mysql2"
 
 gemspec :path => "../"

--- a/lib/second_base/databases.rake
+++ b/lib/second_base/databases.rake
@@ -73,6 +73,14 @@ namespace :db do
         SecondBase.on_base { Rake::Task['db:schema:load'].execute }
       end
 
+      namespace :cache do
+
+        task :dump do
+          SecondBase.on_base { Rake::Task['db:schema:cache:dump'].execute }
+        end
+
+      end
+
     end
 
     namespace :structure do
@@ -109,7 +117,7 @@ end
 %w{
   create:all create drop:all purge:all purge
   migrate migrate:status abort_if_pending_migrations
-  schema:load structure:load
+  schema:load schema:cache:dump structure:load
   test:purge test:load_schema test:load_structure test:prepare
 }.each do |name|
   task = Rake::Task["db:#{name}"] rescue nil

--- a/lib/second_base/railtie.rb
+++ b/lib/second_base/railtie.rb
@@ -31,6 +31,15 @@ module SecondBase
       config.watchable_files.concat ["#{secondbase_dir}/schema.rb", "#{secondbase_dir}/structure.sql"]
     end
 
+    initializer 'second_base.check_schema_cache_dump', after: 'active_record.check_schema_cache_dump' do |app|
+      use_cache  = config.active_record.use_schema_cache_dump
+      cache_file = app.root.join(config.second_base.path, 'schema_cache.dump')
+      if use_cache && File.file?(cache_file)
+        cache = Marshal.load File.binread(cache_file)
+        SecondBase::Base.connection.schema_cache = cache
+      end
+    end
+
     def config_path
       config.second_base.path
     end

--- a/test/cases/dbtask_test.rb
+++ b/test/cases/dbtask_test.rb
@@ -185,10 +185,11 @@ class DbTaskTest < SecondBase::TestCase
     assert File.file?(dummy_secondbase_schema_cache), 'dummy secondbase schema cache does not exist'
     cache1 = Marshal.load(File.binread(dummy_schema_cache))
     cache2 = Marshal.load(File.binread(dummy_secondbase_schema_cache))
-    assert cache1.data_sources('posts'),    'base should have posts table in cache'
-    refute cache1.data_sources('comments'), 'base should not have comments table in cache'
-    refute cache2.data_sources('posts'),    'secondbase should not have posts table in cache'
-    assert cache2.data_sources('comments'), 'secondbase should have comments table in cache'
+    source_method = rails_50_up? ? :data_sources : :tables
+    assert cache1.send(source_method, 'posts'),    'base should have posts table in cache'
+    refute cache1.send(source_method, 'comments'), 'base should not have comments table in cache'
+    refute cache2.send(source_method, 'posts'),    'secondbase should not have posts table in cache'
+    assert cache2.send(source_method, 'comments'), 'secondbase should have comments table in cache'
   end
 
   def test_abort_if_pending

--- a/test/cases/dbtask_test.rb
+++ b/test/cases/dbtask_test.rb
@@ -176,6 +176,21 @@ class DbTaskTest < SecondBase::TestCase
     assert_connection_tables SecondBase::Base, ['comments']
   end
 
+  def test_db_test_schema_cache_dump_xxx
+    run_db :create
+    run_db :migrate
+    assert_dummy_databases
+    Dir.chdir(dummy_root) { `rake db:schema:cache:dump` }
+    assert File.file?(dummy_schema_cache), 'dummy schema cache does not exist'
+    assert File.file?(dummy_secondbase_schema_cache), 'dummy secondbase schema cache does not exist'
+    cache1 = Marshal.load(File.binread(dummy_schema_cache))
+    cache2 = Marshal.load(File.binread(dummy_secondbase_schema_cache))
+    assert cache1.data_sources('posts'),    'base should have posts table in cache'
+    refute cache1.data_sources('comments'), 'base should not have comments table in cache'
+    refute cache2.data_sources('posts'),    'secondbase should not have posts table in cache'
+    assert cache2.data_sources('comments'), 'secondbase should have comments table in cache'
+  end
+
   def test_abort_if_pending
     run_db :create
     run_db :migrate

--- a/test/cases/dbtask_test.rb
+++ b/test/cases/dbtask_test.rb
@@ -176,7 +176,7 @@ class DbTaskTest < SecondBase::TestCase
     assert_connection_tables SecondBase::Base, ['comments']
   end
 
-  def test_db_test_schema_cache_dump_xxx
+  def test_db_test_schema_cache_dump
     run_db :create
     run_db :migrate
     assert_dummy_databases

--- a/test/test_helpers/dummy_app_helpers.rb
+++ b/test/test_helpers/dummy_app_helpers.rb
@@ -29,8 +29,16 @@ module SecondBase
       dummy_db.join 'schema.rb'
     end
 
+    def dummy_schema_cache
+      dummy_db.join 'schema_cache.dump'
+    end
+
     def dummy_secondbase_schema
       dummy_db.join('secondbase', 'schema.rb')
+    end
+
+    def dummy_secondbase_schema_cache
+      dummy_db.join('secondbase', 'schema_cache.dump')
     end
 
     def dummy_database_sqlite

--- a/test/test_helpers/dummy_app_helpers.rb
+++ b/test/test_helpers/dummy_app_helpers.rb
@@ -62,6 +62,8 @@ module SecondBase
     def delete_dummy_files
       FileUtils.rm_rf dummy_schema
       FileUtils.rm_rf dummy_secondbase_schema
+      FileUtils.rm_rf dummy_schema_cache
+      FileUtils.rm_rf dummy_secondbase_schema_cache
       Dir.chdir(dummy_db) { Dir['**/structure.sql'].each { |structure| FileUtils.rm_rf(structure) } }
       Dir.chdir(dummy_db) { FileUtils.rm_rf(dummy_database_sqlite) } if dummy_database_sqlite
       FileUtils.rm_rf(dummy_migration[:file]) if defined?(@dummy_migration) && @dummy_migration


### PR DESCRIPTION
For a long time (since Rails 4) ActiveRecord [has had](https://github.com/rails/rails/pull/5162) a schema cache that assist in complex reflection DB loads. This feature is going to [get a little better](https://github.com/rails/rails/pull/27042) in Rails 5.1 and change to YAML formatting vs a Marshal dump. Never heard of the schema cache? Read more here:

**Rails feature that you've never heard about: schema cache**
http://blog.iempire.ru/2016/12/13/schema-cache/

First, was pretty excited to see how our on base again won for us by changing the db paths. So this was easy to implement via our standard practice. I choose not to get into monkey patching or alias the ActiveRecord's Railtie initializers. Rather, I added a section to the README under the advanced section on how to create an initializer that would mimic what ActiveRecord is doing. Thoughts?