### PR TITLE
Use the value of SCHEMA_FORMAT env

### DIFF
--- a/test/cases/dbtask_test.rb
+++ b/test/cases/dbtask_test.rb
@@ -176,6 +176,17 @@ class DbTaskTest < SecondBase::TestCase
     assert_connection_tables SecondBase::Base, ['comments']
   end
 
+  def test_db_test_load_schema_via_env
+    run_db :create
+    assert_dummy_databases
+    run_db 'test:purge'
+    Dir.chdir(dummy_root) { `env SCHEMA_FORMAT=ruby rake db:migrate` }
+    Dir.chdir(dummy_root) { `rake db:test:load_schema` }
+    establish_connection
+    assert_connection_tables ActiveRecord::Base, ['users', 'posts']
+    assert_connection_tables SecondBase::Base, ['comments']
+  end
+
   def test_db_test_schema_cache_dump
     run_db :create
     run_db :migrate

--- a/test/dummy_apps/rails_five/init.rb
+++ b/test/dummy_apps/rails_five/init.rb
@@ -31,7 +31,7 @@ module Dummy
     # Keep pending test:prepare via pending migrations from running.
     config.active_record.maintain_test_schema = false if ActiveRecord::Base.respond_to?(:maintain_test_schema)
 
-    config.active_record.schema_format = ENV['SCHEMA_FORMAT'] ? :sql : :ruby
+    config.active_record.schema_format = (ENV['SCHEMA_FORMAT'] || :ruby).to_sym
 
     if ENV['WITH_SECONDBASE_TASKS'].present?
       config.second_base.run_with_db_tasks = ENV['WITH_SECONDBASE_TASKS'] == 'true'

--- a/test/dummy_apps/rails_four/init.rb
+++ b/test/dummy_apps/rails_four/init.rb
@@ -31,7 +31,7 @@ module Dummy
     # Keep pending test:prepare via pending migrations from running.
     config.active_record.maintain_test_schema = false if ActiveRecord::Base.respond_to?(:maintain_test_schema)
 
-    config.active_record.schema_format = ENV['SCHEMA_FORMAT'] ? :sql : :ruby
+    config.active_record.schema_format = (ENV['SCHEMA_FORMAT'] || :ruby).to_sym
 
     if ENV['WITH_SECONDBASE_TASKS'].present?
       config.second_base.run_with_db_tasks = ENV['WITH_SECONDBASE_TASKS'] == 'true'


### PR DESCRIPTION
The test cases set the value of `SCHEMA_FORMAT` env, but the code in `init.rb` treated it as a flag.