### PR TITLE
Respect Rails config for migrations path when generating migration.

### DIFF
--- a/lib/rails/second_base/generators/migration_generator.rb
+++ b/lib/rails/second_base/generators/migration_generator.rb
@@ -15,7 +15,12 @@ module SecondBase
     include(Module.new{
 
       def migration_template(*args)
-        args[1].sub! 'db/migrate', "#{Railtie.config_path}/migrate" if args[1]
+        path = Pathname
+               .new(Rails.application.config.paths['db/migrate'].first)
+               .relative_path_from(Rails.root)
+               .to_s
+
+        args[1].sub! path, "#{Railtie.config_path}/migrate" if args[1]
         super(*args)
       end
 


### PR DESCRIPTION
If the user has customized where migrations live for the primary DB, the generator fails to replace that path with the one for the secondary DB.  This ensures that the substitution is properly applied.

This fixes #51 