### PR TITLE
fix rake tasks for rails engine

### DIFF
--- a/lib/second_base/databases.rake
+++ b/lib/second_base/databases.rake
@@ -1,95 +1,95 @@
-namespace :db do
+db_namespace = namespace :db do
   namespace :second_base do
 
     namespace :create do
       desc 'Creates ALL DBs configured for Second base' unless SecondBase::Railtie.run_with_db_tasks?
       task :all => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:create:all'].execute }
+        SecondBase.on_base { db_namespace['create:all'].execute }
       end
     end
 
     desc 'Creates the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:secondbase:create:all to create all databases in the config). Without RAILS_ENV it defaults to creating the development and test databases.' unless SecondBase::Railtie.run_with_db_tasks?
     task :create => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:create'].execute }
+      SecondBase.on_base { db_namespace['create'].execute }
     end
 
     namespace :drop do
       desc 'Drops the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:secondbase:drop:all to drop all databases in the config). Without RAILS_ENV it defaults to dropping the development and test databases.' unless SecondBase::Railtie.run_with_db_tasks?
       task :all => ['db:load_config']  do
-        SecondBase.on_base { Rake::Task['db:drop:all'].execute }
+        SecondBase.on_base { db_namespace['drop:all'].execute }
       end
     end
 
     namespace :purge do
       desc 'Purges (empties) ALL DBs configured for Second base' unless SecondBase::Railtie.run_with_db_tasks?
       task :all => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:purge:all'].execute }
+        SecondBase.on_base { db_namespace['purge:all'].execute }
       end
     end
 
     desc 'Empty the database from DATABASE_URL or config/database.yml for the current RAILS_ENV (use db:secondbase:drop:all to drop all databases in the config). Without RAILS_ENV it defaults to purging the development and test databases.' unless SecondBase::Railtie.run_with_db_tasks?
     task :purge => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:purge'].execute }
+      SecondBase.on_base { db_namespace['purge'].execute }
     end
 
     desc 'Migrate the database (options: VERSION=x, VERBOSE=false, SCOPE=blog).' unless SecondBase::Railtie.run_with_db_tasks?
     task :migrate => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:migrate'].execute }
+      SecondBase.on_base { db_namespace['migrate'].execute }
     end
 
     namespace :migrate do
 
       desc 'Rollbacks the database one migration and re migrate up (options: STEP=x, VERSION=x).' unless SecondBase::Railtie.run_with_db_tasks?
       task :redo => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:migrate:redo'].execute }
+        SecondBase.on_base { db_namespace['migrate:redo'].execute }
       end
 
       desc 'Runs the "up" for a given migration VERSION.'
       task :up => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:migrate:up'].execute }
+        SecondBase.on_base { db_namespace['migrate:up'].execute }
       end
 
       desc 'Runs the "down" for a given migration VERSION.'
       task :down => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:migrate:down'].execute }
+        SecondBase.on_base { db_namespace['migrate:down'].execute }
       end
 
       desc 'Display status of migrations'
       task :status => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:migrate:status'].execute }
+        SecondBase.on_base { db_namespace['migrate:status'].execute }
       end
 
     end
 
     desc 'Rolls the schema back to the previous version (specify steps w/ STEP=n).'
     task :rollback => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:rollback'].execute }
+      SecondBase.on_base { db_namespace['rollback'].execute }
     end
 
     desc 'Drops and recreates the database from db/schema.rb for the current environment and loads the seeds.'
     task :forward => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:forward'].execute }
+      SecondBase.on_base { db_namespace['forward'].execute }
     end
 
     task :abort_if_pending_migrations do
-      SecondBase.on_base { Rake::Task['db:abort_if_pending_migrations'].execute }
+      SecondBase.on_base { db_namespace['abort_if_pending_migrations'].execute }
     end
 
     desc 'Retrieves the current schema version number'
     task :version => ['db:load_config'] do
-      SecondBase.on_base { Rake::Task['db:version'].execute }
+      SecondBase.on_base { db_namespace['version'].execute }
     end
 
     namespace :schema do
       # desc 'Load a schema.rb file into the database' unless SecondBase::Railtie.run_with_db_tasks?
       task :load => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:schema:load'].execute }
+        SecondBase.on_base { db_namespace['schema:load'].execute }
       end
 
       namespace :cache do
         desc 'Create a db/schema_cache.dump file.' unless SecondBase::Railtie.run_with_db_tasks?
         task :dump => ['db:load_config'] do
-          SecondBase.on_base { Rake::Task['db:schema:cache:dump'].execute }
+          SecondBase.on_base { db_namespace['schema:cache:dump'].execute }
         end
 
       end
@@ -99,7 +99,7 @@ namespace :db do
     namespace :structure do
       # desc 'Recreate the databases from the structure.sql file' unless SecondBase::Railtie.run_with_db_tasks?
       task :load => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:structure:load'].execute }
+        SecondBase.on_base { db_namespace['structure:load'].execute }
       end
 
     end
@@ -107,22 +107,22 @@ namespace :db do
     namespace :test do
       desc 'Empty the test database' unless SecondBase::Railtie.run_with_db_tasks?
       task :purge => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:test:purge'].execute }
+        SecondBase.on_base { db_namespace['test:purge'].execute }
       end
 
       # desc 'Recreate the test database from an existent schema.rb file' unless SecondBase::Railtie.run_with_db_tasks?
       task :load_schema => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:test:load_schema'].execute }
+        SecondBase.on_base { db_namespace['test:load_schema'].execute }
       end
 
       # desc 'Recreate the test database from the current schema' unless SecondBase::Railtie.run_with_db_tasks?
       task :load_structure => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:test:load_structure'].execute }
+        SecondBase.on_base { db_namespace['test:load_structure'].execute }
       end
 
       desc 'Check for pending migrations and load the test schema' unless SecondBase::Railtie.run_with_db_tasks?
       task :prepare => ['db:load_config'] do
-        SecondBase.on_base { Rake::Task['db:test:prepare'].execute }
+        SecondBase.on_base { db_namespace['test:prepare'].execute }
       end
 
     end
@@ -136,10 +136,10 @@ end
   schema:load schema:cache:dump structure:load
   test:purge test:load_schema test:load_structure test:prepare
 }.each do |name|
-  task = Rake::Task["db:#{name}"] rescue nil
+  task = db_namespace["#{name}"] rescue nil
   next unless task && SecondBase::Railtie.run_with_db_tasks?
   task.enhance do
-    Rake::Task["db:load_config"].invoke
-    Rake::Task["db:second_base:#{name}"].invoke
+    db_namespace["load_config"].invoke
+    db_namespace["second_base:#{name}"].invoke
   end
 end

--- a/lib/second_base/databases_rails_five.rake
+++ b/lib/second_base/databases_rails_five.rake
@@ -1,7 +1,7 @@
-namespace :db do
+db_namespace = namespace :db do
   namespace :second_base do
     task "drop:_unsafe" do
-      SecondBase.on_base { Rake::Task['db:drop:_unsafe'].execute }
+      SecondBase.on_base { db_namespace['drop:_unsafe'].execute }
     end
 
     namespace :migrate do
@@ -14,10 +14,10 @@ end
 %w{
   drop:_unsafe
 }.each do |name|
-  task = Rake::Task["db:#{name}"] rescue nil
+  task = db_namespace[name] rescue nil
   next unless task && SecondBase::Railtie.run_with_db_tasks?
   task.enhance do
-    Rake::Task["db:load_config"].invoke
-    Rake::Task["db:second_base:#{name}"].invoke
+    db_namespace["load_config"].invoke
+    db_namespace["second_base:#{name}"].invoke
   end
 end

--- a/lib/second_base/databases_rails_four.rake
+++ b/lib/second_base/databases_rails_four.rake
@@ -1,7 +1,7 @@
-namespace :db do
+db_namespace = namespace :db do
   namespace :second_base do
     task :drop do
-      SecondBase.on_base { Rake::Task['db:drop'].execute }
+      SecondBase.on_base { db_namespace['drop'].execute }
     end
 
     namespace :migrate do
@@ -14,10 +14,10 @@ end
 %w{
   drop
 }.each do |name|
-  task = Rake::Task["db:#{name}"] rescue nil
+  task = db_namespace[name] rescue nil
   next unless task && SecondBase::Railtie.run_with_db_tasks?
   task.enhance do
-    Rake::Task["db:load_config"].invoke
-    Rake::Task["db:second_base:#{name}"].invoke
+    db_namespace["load_config"].invoke
+    db_namespace["second_base:#{name}"].invoke
   end
 end


### PR DESCRIPTION
When you are developing rails engine which has connects with two databases you don't have ordinary rails tasks like `db:migrate` `db:structure:load` etc. They are moved into `app` namespace.

so instead of `rake db:migrate` you need to right `rake app:db:migrate`.

when you use gem with `railtie` that has rake tasks in rails engine those task namespaced into `app` too.
Problem appears when you want to run another rake task inside of yours. For example when we inside `app` namespace we need to run `app:db:migrate` instead of `db:migrate.

in this PR I've solved this problem in a same way as `active_record` does - just call tasks using name related to current `db` namespace